### PR TITLE
fix: set <event> to 'Flood' per CAP 1.2 §3.2.4

### DIFF
--- a/lib/functions/processMessage.js
+++ b/lib/functions/processMessage.js
@@ -56,6 +56,11 @@ module.exports.processMessage = async (event) => {
     // If the last message is active then update references and msgtype
     updateReferences(lastMessage, xmlResult)
 
+    // Set <event> to describe the hazard type per CAP 1.2 §3.2.4.
+    // The upstream FWIS system incorrectly sends msgType values ("Alert",
+    // "Update", "Cancel") or internal action codes in this field.
+    xmlResult.alert.info[0].event[0] = 'Flood'
+
     const message = new Message(xmlResult)
 
     const validationResult2 = await validate(message.data.alert, xsdSchema)


### PR DESCRIPTION
## Problem

The `<info><event>` field in published CAP alerts currently contains a reference to the message type, e.g `Issue`, `Update` or `Remove` rather than describing the hazard as required by the CAP 1.2 specification.

This PR fixes the issue by setting the `<info><event>` field for every alert to `"Flood"`.

As a future piece of work, a more specific OET event term could be derived from the FWIS area code or warning type to be more specific, e.g. using `Coastal Flood` for coastal alerts instead of the generic `Flood`.


### Examples from the live feed

Source: `https://environment.data.gov.uk/cap/flood-alerts.atom`

```xml
<msgType>Alert</msgType>
...
<info>
  <event>Issue</event>  <!-- Should describe the hazard, not the message type -->
```

```xml
<!-- Message 117004 (2026-03-07) -->
<msgType>Update</msgType>
...
<info>
  <event>Update</event>  <!-- Should describe the hazard, not the message type -->
```

```xml
<!-- Message 116867 (2026-03-06) -->
<msgType>Cancel</msgType>
...
<info>
  <event>Remove</event>  <!-- Should describe the hazard, not the message type -->
```

Every alert checked in the current feed exhibits this pattern — `<event>` always mirrors `<msgType>`.


## CAP 1.2 specification

Per the OASIS CAP 1.2 standard, these are distinct fields with different purposes:

- **`<msgType>`** (§3.1) — the nature of the message: "Alert", "Update", "Cancel", "Ack", "Error"
- **`<event>`** (§3.2.4) — *"The text denoting the type of the subject event of the alert message"*

`<msgType>` describes what the *message* is doing (issuing, updating, cancelling). `<event>` describes the *hazard* (flooding).

The [Google Public Alerts documentation](https://developers.google.com/public-alerts/guides/generate-alerts) further clarifies that `<event>` appears in alert titles and should be *"short (less than 35 characters) and descriptive enough for the public to understand"*, with examples like `<event>Tornado</event>`.


## Suggested `<event>` values

The [OASIS CAP Event Terms List (ETL) v1.2](https://docs.oasis-open.org/emergency/cap-event-terms/v1.2/cap-event-terms-v1.2.html) defines standardised event terms.

From that list, the following terms are relevant for the Environment Agency flood warning service:

| OET Code | Event Term |
|----------|-----------|
| OET-081 | Flood |
| OET-042 | Coastal Flood |
| OET-079 | Flash Flood |
| OET-140 | Overland Flood |

Using `Flood` for all alerts is a pragmatic starting point and is implemented in this PR.

As a future piece of work, the event term could be derived from the FWIS area code or warning type to be more specific, e.g. using `Coastal Flood` for coastal alerts instead of the generic `Flood`.

## Impact

- CAP consumers (including aggregators, alerting platforms, and Google Public Alerts) rely on `<event>` to categorise and display alerts by hazard type
- With the current output, all Environment Agency flood alerts appear as event type "Update" or "Alert", making them indistinguishable from other hazard categories
- The `<event>` value is what end users see first — "Update" tells them nothing; "Flood" tells them everything they need

## Root cause

The `<event>` value comes from the upstream FWIS system and passes through `processMessage.js` unchanged. The test fixtures in this repository confirm the upstream has historically sent incorrect values in this field (e.g. `"064 Issue Flood Alert EA"` in `test/lib/functions/data/capAlert.json`).

The `updateReferences()` function already transforms `<msgType>` and `<references>` but does not touch `<event>`. A similar one-line transformation resolves the issue.

## Fix

This PR sets `<event>` to `Flood` after the existing `updateReferences()` call in `lib/functions/processMessage.js`:

```javascript
// Set <event> to describe the hazard type per CAP 1.2 §3.2.4.
// The upstream FWIS system incorrectly sends msgType values ("Alert",
// "Update", "Cancel") or internal action codes in this field.
xmlResult.alert.info[0].event[0] = 'Flood'
```

As mentioned above, as a future piece of work, the event term could be derived from the FWIS area code or warning type to be more specific, e.g. using `Coastal Flood` for coastal alerts instead of the generic `Flood`.


## References

- [CAP 1.2 spec §3.2.4](http://docs.oasis-open.org/emergency/cap/v1.2/CAP-v1.2.html)
- [OASIS CAP ETL v1.2](https://docs.oasis-open.org/emergency/cap-event-terms/v1.2/cap-event-terms-v1.2.html)
- [Google Public Alerts](https://developers.google.com/public-alerts/guides/generate-alerts)
- [Live feed](https://environment.data.gov.uk/cap/flood-alerts.atom)
